### PR TITLE
chore: drop upraises

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,12 @@ jobs:
             label: macOS,
             runner: macos-latest
           }
-          - {
-            icon: 🏁,
-            label: Windows,
-            runner: windows-latest
-          }
+          # TODO https://github.com/nim-lang/choosenim/issues/27
+          # - {
+          #   icon: 🏁,
+          #   label: Windows,
+          #   runner: windows-latest
+          # }
         nim: [1.6.18]
     name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim }}
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,8 @@ jobs:
             label: Windows,
             runner: windows-latest
           }
-        nim: [1.6.18]
+        # Earliest supported and latest nim
+        nim: [1.6.18, "stable"]
     name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim }}
     runs-on: ${{ matrix.platform.runner }}
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,11 @@ jobs:
             label: macOS,
             runner: macos-latest
           }
-          # TODO https://github.com/nim-lang/choosenim/issues/27
-          # - {
-          #   icon: 🏁,
-          #   label: Windows,
-          #   runner: windows-latest
-          # }
+          - {
+            icon: 🏁,
+            label: Windows,
+            runner: windows-latest
+          }
         nim: [1.6.18]
     name: ${{ matrix.platform.icon }} ${{ matrix.platform.label }} - Nim v${{ matrix.nim }}
     runs-on: ${{ matrix.platform.runner }}
@@ -33,9 +32,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: iffy/install-nim@v5
+    - uses: jiro4989/setup-nim-action@v2
       with:
-        version: ${{ matrix.nim }}
+        nim-version: ${{matrix.nim}}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install
       run: nimble install -y
     - name: Build and run tests

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ TODO
 
 nimble.develop
 nimble.paths
+nimbledeps

--- a/config.nims
+++ b/config.nims
@@ -2,7 +2,8 @@
 --styleCheck:error
 --threads:on
 --tlsEmulation:off
-# begin Nimble config (version 1)
-when fileExists("nimble.paths"):
+# begin Nimble config (version 2)
+--noNimblePath
+when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config

--- a/leopard.nimble
+++ b/leopard.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "leopard"
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Status Research & Development GmbH"
 description   = "A wrapper for Leopard-RS"
 license       = "Apache License 2.0 or MIT"
@@ -10,4 +10,4 @@ installDirs   = @["vendor"]
 requires "nim >= 1.6.0",
          "stew",
          "unittest2",
-         "upraises >= 0.1.0 & < 0.2.0"
+         "results"

--- a/leopard.nimble
+++ b/leopard.nimble
@@ -8,6 +8,5 @@ license       = "Apache License 2.0 or MIT"
 installDirs   = @["vendor"]
 
 requires "nim >= 1.6.0",
-         "stew",
          "unittest2",
          "results"

--- a/leopard/leopard.nim
+++ b/leopard/leopard.nim
@@ -7,12 +7,9 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import pkg/upraises
-push: {.upraises: [].}
+{.push raises: [].}
 
-{.deadCodeElim: on.}
-
-import pkg/stew/results
+import pkg/results
 
 import ./wrapper
 import ./utils

--- a/leopard/utils/allocs.nim
+++ b/leopard/utils/allocs.nim
@@ -7,10 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import pkg/upraises
-push: {.upraises: [].}
-
-{.deadCodeElim: on.}
+{.push raises: [].}
 
 import system/ansi_c
 

--- a/leopard/utils/cpuinfo_x86.nim
+++ b/leopard/utils/cpuinfo_x86.nim
@@ -7,10 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import pkg/upraises
-push: {.upraises: [].}
-
-{.deadCodeElim: on.}
+{.push raises: [].}
 
 # From awr1: https://github.com/nim-lang/Nim/pull/11816/files
 

--- a/leopard/wrapper.nim
+++ b/leopard/wrapper.nim
@@ -57,8 +57,7 @@
 ## Conference on File and Storage Technologies, San Jose, 2013
 
 
-import pkg/upraises
-push: {.upraises: [].}
+{.push raises: [].}
 
 ## -----------------------------------------------------------------------------
 ## Build configuration

--- a/nimble.lock
+++ b/nimble.lock
@@ -1,35 +1,39 @@
 {
-  "version": 1,
+  "version": 2,
   "packages": {
-    "unittest2": {
-      "version": "0.0.4",
-      "vcsRevision": "f180f596c88dfd266f746ed6f8dbebce39c824db",
-      "url": "https://github.com/status-im/nim-unittest2.git",
+    "results": {
+      "version": "0.5.1",
+      "vcsRevision": "df8113dda4c2d74d460a8fa98252b0b771bf1f27",
+      "url": "https://github.com/arnetheduck/nim-results",
       "downloadMethod": "git",
       "dependencies": [],
       "checksums": {
-        "sha1": "fa309c41eaf6ef57895b9e603f2620a2f6e11780"
+        "sha1": "a9c011f74bc9ed5c91103917b9f382b12e82a9e7"
       }
     },
-    "upraises": {
-      "version": "0.1.0",
-      "vcsRevision": "ff4f8108e44fba9b35cac535ab63d3927e8fd3c2",
-      "url": "https://github.com/markspanbroek/upraises.git",
+    "unittest2": {
+      "version": "0.2.5",
+      "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
+      "url": "https://github.com/status-im/nim-unittest2",
       "downloadMethod": "git",
       "dependencies": [],
       "checksums": {
-        "sha1": "a0243c8039e12d547dbb2e9c73789c16bb8bc956"
+        "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
       }
     },
     "stew": {
-      "version": "0.1.0",
-      "vcsRevision": "6ad35b876fb6ebe0dfee0f697af173acc47906ee",
-      "url": "https://github.com/status-im/nim-stew.git",
+      "version": "0.4.2",
+      "vcsRevision": "b66168735d6f3841c5239c3169d3fe5fe98b1257",
+      "url": "https://github.com/status-im/nim-stew",
       "downloadMethod": "git",
-      "dependencies": [],
+      "dependencies": [
+        "results",
+        "unittest2"
+      ],
       "checksums": {
-        "sha1": "46d58c4feb457f3241e3347778334e325dce5268"
+        "sha1": "928e82cb8d2f554e8f10feb2349ee9c32fee3a8c"
       }
     }
-  }
+  },
+  "tasks": {}
 }

--- a/nimble.lock
+++ b/nimble.lock
@@ -1,16 +1,6 @@
 {
   "version": 2,
   "packages": {
-    "results": {
-      "version": "0.5.1",
-      "vcsRevision": "df8113dda4c2d74d460a8fa98252b0b771bf1f27",
-      "url": "https://github.com/arnetheduck/nim-results",
-      "downloadMethod": "git",
-      "dependencies": [],
-      "checksums": {
-        "sha1": "a9c011f74bc9ed5c91103917b9f382b12e82a9e7"
-      }
-    },
     "unittest2": {
       "version": "0.2.5",
       "vcsRevision": "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189",
@@ -21,17 +11,14 @@
         "sha1": "02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9"
       }
     },
-    "stew": {
-      "version": "0.4.2",
-      "vcsRevision": "b66168735d6f3841c5239c3169d3fe5fe98b1257",
-      "url": "https://github.com/status-im/nim-stew",
+    "results": {
+      "version": "0.5.1",
+      "vcsRevision": "df8113dda4c2d74d460a8fa98252b0b771bf1f27",
+      "url": "https://github.com/arnetheduck/nim-results",
       "downloadMethod": "git",
-      "dependencies": [
-        "results",
-        "unittest2"
-      ],
+      "dependencies": [],
       "checksums": {
-        "sha1": "928e82cb8d2f554e8f10feb2349ee9c32fee3a8c"
+        "sha1": "a9c011f74bc9ed5c91103917b9f382b12e82a9e7"
       }
     }
   },

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -1,6 +1,6 @@
 import std/random
 
-import pkg/stew/results
+import pkg/results
 import ../leopard
 
 proc randomCRCPacket*(data: var openArray[byte]) =

--- a/tests/testleopard.nim
+++ b/tests/testleopard.nim
@@ -2,7 +2,7 @@ import std/random
 import std/sets
 
 import pkg/unittest2
-import pkg/stew/results
+import pkg/results
 
 import ../leopard
 import ./helpers


### PR DESCRIPTION
* use `results` directly, without `stew`
* switches nim install method (the existing one uses choosenim which is obsolete)
* add nim stable testing
